### PR TITLE
Update docker_installation/tasks/preparing.yml

### DIFF
--- a/ansible/roles/docker_installation/tasks/preparing.yml
+++ b/ansible/roles/docker_installation/tasks/preparing.yml
@@ -16,3 +16,7 @@
     mode: 0644
     owner: root
     group: root
+
+- name: Update apt cache
+  ansible.builtin.command:
+    cmd: apt update


### PR DESCRIPTION
Without running apt update, package installation may fail because the system's package cache is not updated to recognize the newly added repository.
its simple but it makes issue