### PR TITLE
fix docker_setup role

### DIFF
--- a/ansible/roles/docker_setup/tasks/preparing.yml
+++ b/ansible/roles/docker_setup/tasks/preparing.yml
@@ -16,3 +16,7 @@
     mode: 0644
     owner: root
     group: root
+
+- name: Update apt cache
+  ansible.builtin.command:
+    cmd: apt update


### PR DESCRIPTION
in RahBia-Live-Coding/ansible/roles/docker_setup/tasks/preparing.yml
It must have an apt update to update the apt cache after updating the GPG keys and apt repos